### PR TITLE
Commented out MAINTAINER as it has been deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:2.7-alpine
-MAINTAINER Jeff Li <jeff.li@mackenzieinvestments.com>
+# MAINTAINER Jeff Li <jeff.li@mackenzieinvestments.com>
 
 # Add Tini
 RUN apk add --update tini


### PR DESCRIPTION
Hi!
The instruction `MAINTAINER `has been **deprecated** according to the docker docs so i commented it out instead of removing it so that your names remains. I hope you don't mind, i did it to prevent any issues when someone pulls your image.
Link to docks :- https://docs.docker.com/engine/reference/builder/#maintainer-deprecated
![image](https://user-images.githubusercontent.com/35080655/93254717-6c38ed00-f7b6-11ea-957b-eaaa38c82ac9.png)
